### PR TITLE
No more whitespace! Begone! And guide cards now resize to text

### DIFF
--- a/OverclockingGuide.html
+++ b/OverclockingGuide.html
@@ -45,7 +45,7 @@
         <button class="glow-on-hover" onclick="goBack()">&#8592; Go Back</button>
         <div id="maintext">
             <br><br>
-            <h1>T-REX guide</h1>
+            <h1>Overclocking Guide</h1>
             <p>
                 Made by Plerion#6666 heavily based on Happy Pill#9683's guide - Last update 6/15/2022 @9:46 UTC-8
             </p>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -6,7 +6,14 @@
   list-style: none;
   font-family: "lato", sans-serif;
 }
-
+html {
+  height: 100%
+}
+body {
+  background-color: #c69c6c;
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+}
 /* Header Formatting - 3 different for each HTML page variant */
 .container {
   width: 100%;
@@ -32,11 +39,11 @@
   width: 100%;
   height:100%;
   background-image: linear-gradient(#303136, #c69c6c);
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
   background-position: center;
-  background-size: cover;
   padding-left: 8%;
   padding-right: 8%;
-  padding-bottom: 25vh;
   box-sizing: border-box;
 }
 /* End Header Formatting */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -30,13 +30,13 @@
 }
 .container3 {
   width: 100%;
-  height:max-content;
+  height:100%;
   background-image: linear-gradient(#303136, #c69c6c);
   background-position: center;
   background-size: cover;
   padding-left: 8%;
   padding-right: 8%;
-  padding-bottom: 20px;
+  padding-bottom: 25vh;
   box-sizing: border-box;
 }
 /* End Header Formatting */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -222,7 +222,6 @@ a {
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2); /* this adds the "card" effect */
   border-radius: 5px;
   min-height: 200px;
-  max-height: 200px;
   padding: 16px;
   text-align: center;
   background-color: #303136;


### PR DESCRIPTION
Uh, yea, it took me way too long to figure this out, anyway, whitespace is now gone no matter the size of the window. Also, there was an issue where the cards to click into the guides would not resize to fit behind the text, that is now fixed as well