### PR TITLE
Updated links to 0.5.6

### DIFF
--- a/Gminer.html
+++ b/Gminer.html
@@ -95,7 +95,7 @@
                             <li>Internet Connection</li>
                             <li>A GPU with 2GB+ VRAM</li>
                             <li>500MB disk space</li>
-                            <li>Have installed Salad 0.5.6 - 0.5.8, found <a href="https://github.com/SaladTechnologies/salad-applications/releases" target="_blank">here</a>.</li>
+                            <li>Have installed Salad 0.5.6, found <a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.6" target="_blank">here</a>.</li>
                             <li>To have mined once before (This is how you get the logs, So the rig and wallet ID)<li>
                         </ul>
                     </div>
@@ -114,7 +114,7 @@
                 <div class="collapsible-content">
                     <div class="content-inner">
                         <p>Here is <a href="https://support.salad.io/hc/en-us/articles/360042215512-How-To-Find-Your-Salad-Log-Files" target="_blank">a guide to finding your Salad logs.</a> You'll need these to find the required IDs.</p>
-                        <p>Salad version 0.5.6 - 0.5.8 will be required to do this. You can find theses here, <a href="https://github.com/SaladTechnologies/salad-applications/releases" target="_blank">Salad github.</a> </p>
+                        <p>Salad version 0.5.6 will be required to do this. You can find theses here, <a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.6" target="_blank">Salad github.</a> </p>
                         <p>It should look something like this:</p>
                         <div class ="row">
                             <div class="column"><img src="images/RigIDs.png" alt="Snow" style="width:100%"></div>

--- a/PhoenixGuide.html
+++ b/PhoenixGuide.html
@@ -101,7 +101,7 @@
                             <li>Internet Connection</li>
                             <li>A dedicated GPU with 3GB+ VRAM</li>
                             <li>500MB disk space</li>
-                            <li>Have installed Salad (<a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.8" target="_blank">0.5.8</a> if you wish to use Nicehash or Ethermine pools)</li>
+                            <li>Have installed Salad (<a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.6" target="_blank">0.5.6</a> if you wish to use Nicehash or Ethermine pools)</li>
 							<li>To have mined once before (This is to generate your Rig and wallet ID, shown in Salad's logs in later steps)</li>
                         </ul>
                     </div>
@@ -122,7 +122,7 @@
                 <div class="collapsible-content">
                     <div class="content-inner">
                         <p>Here is <a href="https://support.salad.com/article/233-salad-log-files" target="_blank">a guide to finding your Salad logs.</a> You'll need these to find the required IDs.</p>
-						<p>Note that Salad 1.0 no longer gives the required IDs to mine with Nicehash and Ethermine in the logs - If you wish to use either of these pools, you'll have to use Salad <a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.8" target="_blank">0.5.8</a> to get the IDs required for these pools.</p>
+						<p>Note that Salad 1.0 no longer gives the required IDs to mine with Nicehash and Ethermine in the logs - If you wish to use either of these pools, you'll have to use Salad <a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.6" target="_blank">0.5.6</a> to get the IDs required for these pools.</p>
 						<p>You may be able to still get your Prohashing IDs in Salad 1.0 by mining at least once with it, heading to your <a href="https://support.salad.com/article/233-salad-log-files" target="_blank">Salad logs folder</a>, opening the folder for one of the miners (e.g. T-Rex), opening the latest log inside of said folder, then at the very top you should see something like "-u salad -p (A bunch of random characters)".</p>
 						<br>
                         <p>It should look something like this:</p>

--- a/T-REX.html
+++ b/T-REX.html
@@ -95,7 +95,7 @@
                             <li>Internet Connection</li>
                             <li>A GPU with 4GB+ VRAM</li>
                             <li>500MB disk space</li>
-                            <li>Have installed Salad (<a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.8" target="_blank">0.5.8</a> if you wish to use Nicehash or Ethermine pools)</li>
+                            <li>Have installed Salad (<a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.6" target="_blank">0.5.6</a> if you wish to use Nicehash or Ethermine pools)</li>
                             <li>To have mined once before (This is to generate your Rig and wallet ID, shown in Salad's logs in later steps)</li>
                         </ul>
                     </div>
@@ -115,7 +115,7 @@
                 <div class="collapsible-content">
                     <div class="content-inner">
                         <p>Here is <a href="https://support.salad.com/article/233-salad-log-files" target="_blank">a guide to finding your Salad logs.</a> You'll need these to find the required IDs.</p>
-                        <p>Note that Salad 1.0 no longer gives the required IDs to mine with Nicehash and Ethermine in the logs - If you wish to use either of these pools, you'll have to use Salad <a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.8" target="_blank">0.5.8</a> to get the IDs required for these pools.</p>
+                        <p>Note that Salad 1.0 no longer gives the required IDs to mine with Nicehash and Ethermine in the logs - If you wish to use either of these pools, you'll have to use Salad <a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.6" target="_blank">0.5.6</a> to get the IDs required for these pools.</p>
 						<p>You may be able to still get your Prohashing IDs in Salad 1.0 by mining at least once with it, heading to your <a href="https://support.salad.com/article/233-salad-log-files" target="_blank">Salad logs folder</a>, opening the folder for one of the miners (e.g. T-Rex), opening the latest log inside of said folder, then at the very top you should see something like "-u salad -p (A bunch of random characters)".</p>
                         <p>It should look something like this:</p>
                         <div class ="row">

--- a/XMRigCPUGuide.html
+++ b/XMRigCPUGuide.html
@@ -95,7 +95,7 @@
                             <li>Internet Connection</li>
                             <li>A CPU and 5GB+ RAM</li>
                             <li>500MB disk space</li>
-                            <li>Have installed Salad 0.5.6 - 0.5.8, found <a href="https://github.com/SaladTechnologies/salad-applications/releases" target="_blank">here</a>.</li>
+                            <li>Have installed Salad 0.5.6, found <a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.6" target="_blank">here</a>.</li>
                             <li>To have mined once before (This is how you get the logs, So the rig and wallet ID)<li>
                         </ul>
                     </div>
@@ -114,7 +114,7 @@
                 <div class="collapsible-content">
                     <div class="content-inner">
                         <p>Here is <a href="https://support.salad.io/hc/en-us/articles/360042215512-How-To-Find-Your-Salad-Log-Files" target="_blank">a guide to finding your Salad logs.</a> You'll need these to find the required IDs.</p>
-                        <p>Salad version 0.5.6 - 0.5.8 will be required to do this. You can find theses here, <a href="https://github.com/SaladTechnologies/salad-applications/releases" target="_blank">Salad github.</a> </p>
+                        <p>Salad version 0.5.6 will be required to do this. You can find theses here, <a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.6" target="_blank">Salad github.</a> </p>
                         <p>It should look something like this:</p>
                         <div class ="row">
                             <div class="column"><img src="images/RigIDs.png" alt="Snow" style="width:100%"></div>

--- a/XMRigGPUGuide.html
+++ b/XMRigGPUGuide.html
@@ -97,7 +97,7 @@
                             <li>Internet Connection</li>
                             <li>A GPU with 4GB+ of VRAM (although T-REX, Phoenix, NBminer or GMiner are recommended for 6GB+ GPUs)</li>
                             <li>500MB disk space</li>
-                            <li>Have installed Salad 0.5.6 - 0.5.8, found <a href="https://github.com/SaladTechnologies/salad-applications/releases" target="_blank">here</a>.</li>
+                            <li>Have installed Salad 0.5.6, found <a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.6" target="_blank">here</a>.</li>
                             <li>To have mined once before (This is how you get the logs, So the rig and wallet ID)<li>
                         </ul>
                     </div>
@@ -128,7 +128,7 @@
                 <div class="collapsible-content">
                     <div class="content-inner">
                         <p>Here is <a href="https://support.salad.io/hc/en-us/articles/360042215512-How-To-Find-Your-Salad-Log-Files" target="_blank">a guide to finding your Salad logs.</a> You'll need these to find the required IDs.</p>
-                        <p>Salad version 0.5.6 - 0.5.8 will be required to do this. You can find theses here, <a href="https://github.com/SaladTechnologies/salad-applications/releases" target="_blank">Salad github.</a> </p>
+                        <p>Salad version 0.5.6 will be required to do this. You can find theses here, <a href="https://github.com/SaladTechnologies/salad-applications/releases/tag/0.5.6" target="_blank">Salad github.</a> </p>
                         <p>It should look something like this:</p>
                         <div class ="row">
                             <div class="column"><img src="images/RigIDs.png" alt="Snow" style="width:100%"></div>


### PR DESCRIPTION
Some testing has been done and it seems like 0.5.8 dosent show or has more issues showing rig id and wallet so changing to version 0.5.6 is better

i left nbminer out of the changes as ozua said they are working on that guide