### PR TITLE
Some changes to cli page

### DIFF
--- a/cli.html
+++ b/cli.html
@@ -140,7 +140,8 @@
                 <div class="cards"><h5>PhoenixMiner</h5>
 				  <div class="suppgpus"><div class="minersuppNVIDIA"><h5>Nvidia</h5></div><div class="minersuppAMD"><h5>AMD</h5></div></div>
 				  
-                  <p>PhoenixMiner, for Nvidia and AMD GPUs to mine ETH (5GB+) and ETC (4GB+) !</p>
+                  <p>For Nvidia and AMD GPUs to mine ETH and ETC!</p>
+                  <p>Supports 4GB+ Vram GPUs!</p>
                   <br>
                   <p>Offers extra commands like GPU usage, temperature threshold, and on-the-go overclocking!</p>
                   <br>
@@ -153,7 +154,8 @@
                 <div class="cards"><h5>T-REX</h5>
 				  <div class="suppgpus"><div class="minersuppNVIDIA"><h5>Nvidia</h5></div><div></div></div>
 				  
-                  <p>For Nvidia GPUs, mines ETH, ETC, and KawPow!</p>
+                  <p>For Nvidia GPUs to mine ETH, ETC, and RVN!</p>
+                  <p>Supports 4GB+ Vram GPUs!</p>
                   <br>
                   <p>Offers low fees for mining, temperature limits, and GPU usage!</p>
                   <br>
@@ -166,9 +168,10 @@
                 <div class="cards"><h5>TeamRedMiner</h5>
         <div class="suppgpus"><div class="minersuppAMD"><h5>AMD</h5></div><div></div></div>
         
-                  <p>For AMD GPUs, mines ETH, ETC, and KawPow!</p>
+                  <p>For AMD GPUs, mines ETH, ETC, and RVN!</p>
+                  <p>Supports 4GB+ Vram GPUs!</p>
                   <br>
-                  <p>Offers extra commands like temp limits and on-the-go overclocking!</p>
+                  <p>Offers extra commands like temperature limits, on-the-go overclocking and more!</p>
                   <br>
                   <h4>Click to learn more</h4>
                   </div>
@@ -179,9 +182,10 @@
               <div class="cards"><h5>NBMiner</h5>
         <div class="suppgpus"><div class="minersuppNVIDIA"><h5>Nvidia</h5></div><div class="minersuppAMD"><h5>AMD</h5></div></div>
         
-                <p>Supports GPUs from 3GB and up, by using either beamv3 or ethereum to mine!</p>
+                <p>For Nvidia and AMD GPUs to mine Beam, ETH, ETC! 
+                <p>Supports 3GB+ Vram GPUs!</p>
                 <br>
-                <p>Offers extra commands like custom GPU usage, temperature thresholds, and completely remove dev fee!</p>
+                <p>Offers extra commands like GPU usage, temperature thresholds, and removable dev fee!</p>
                 <br>
                 <h4>Click to learn more</h4>
                 </div>
@@ -192,7 +196,7 @@
                 <div class="cards"><h5>XMRig CPU</h5>
 				  <div class="suppgpus"><div class="minersuppIntel"><h5>Intel</h5></div><div class="minersuppAMD"><h5>AMD</h5></div></div>
 				  
-                  <p>Used for CPU mining, using the monero coin on the randomx algorithm!</p>
+                  <p>For Intel and AMD CPUs to mine the monero coin on the randomx algorithm!</p>
                   <br>
                   <p>Offers extra commands like custom CPU usage, background mode, and support for nicehash pools!</p>
                   <br>
@@ -205,7 +209,8 @@
                 <div class="cards"><h5>XMRig GPU</h5>
 				  <div class="suppgpus"><div class="minersuppNVIDIA"><h5>Nvidia</h5></div><div class="minersuppAMD"><h5>AMD</h5></div></div>
 				  
-                  <p>Mainly for 4GB+ VRAM GPUs, to mine Monero using the KawPow algorithm!</p>
+                  <p>For Nvidia and AMD GPUs to mine Monero with the KawPow algorithm!</p>
+                  <p>Supports 4GB+ Vram GPUs!</p>
                   <br>
                   <p>Offers extra commands like background mining, and nicehash pools!</p>
                   <br>
@@ -218,7 +223,8 @@
                 <div class="cards"><h5>GMiner</h5>
 				  <div class="suppgpus"><div class="minersuppNVIDIA"><h5>Nvidia</h5></div><div class="minersuppAMD"><h5>AMD</h5></div></div>
 				  
-                  <p>Supports most 2GB+ GPUs, use ETC, Kawpow, Beam, BTG, and Ethereum!</p>
+                  <p>For Nivida and AMD GPUs to mine BTG, RVN, ETH, and ETC!</p>
+                  <p>Supports 2GB+ Vram GPUs!</p>
                   <br>
                   <p>Offers extra commands like custom GPU usage, and on-the-go overclocking!</p>
                   <br>
@@ -229,10 +235,10 @@
 			 <div class="column">
               <a href="OverclockingGuide.html"> <!-- OC Guide -->
                 <div class="cards"><h5>Overclocking</h5>
+                  <div class="suppgpus"><div class="minersuppNVIDIA"><h5>Nvidia</h5></div><div class="minersuppAMD"><h5>AMD</h5></div></div>
+                  <p>Increase GPU performance!</p>
                   <br>
-                  <p>Increase Earnings!</p>
-                  <br>
-                  <p>Overclocking can lower power usage, increase GPU life and maximize earnings !</p>
+                  <p>Overclocking can decrease power usage, increase GPU lifespan and maximize earnings!  </p>
                   <br>
                   <h4>Click to learn more</h4>
                   </div>

--- a/cli.html
+++ b/cli.html
@@ -149,16 +149,42 @@
               </a>
             </div>
             <div class="column">
-              <a href="XMRigGPUGuide.html"> <!-- XMRig GPU CLI guide -->
-                <div class="cards"><h5>XMRig GPU</h5>
-				  <div class="suppgpus"><div class="minersuppNVIDIA"><h5>Nvidia</h5></div><div class="minersuppAMD"><h5>AMD</h5></div></div>
+              <a href="T-REX.html"> <!-- T-REX CLI guide -->
+                <div class="cards"><h5>T-REX</h5>
+				  <div class="suppgpus"><div class="minersuppNVIDIA"><h5>Nvidia</h5></div><div></div></div>
 				  
-                  <p>Mainly for 4GB+ VRAM GPUs, to mine Monero using the KawPow algorithm!</p>
+                  <p>For Nvidia GPUs, mines ETH, ETC, and KawPow!</p>
                   <br>
-                  <p>Offers extra commands like background mining, and nicehash pools!</p>
+                  <p>Offers low fees for mining, temperature limits, and GPU usage!</p>
                   <br>
                   <h4>Click to learn more</h4>
                   </div>
+              </a>
+            </div>
+            <div class="column">
+              <a href="TeamRedMiner.html"> <!-- TeamRedMiner Guide -->
+                <div class="cards"><h5>TeamRedMiner</h5>
+        <div class="suppgpus"><div class="minersuppAMD"><h5>AMD</h5></div><div></div></div>
+        
+                  <p>For AMD GPUs, mines ETH, ETC, and KawPow!</p>
+                  <br>
+                  <p>Offers extra commands like temp limits and on-the-go overclocking!</p>
+                  <br>
+                  <h4>Click to learn more</h4>
+                  </div>
+            </a>
+          </div>
+          <div class="column">
+            <a href="NBMinerGuide.html"> <!-- NBMiner CLI guide -->
+              <div class="cards"><h5>NBMiner</h5>
+        <div class="suppgpus"><div class="minersuppNVIDIA"><h5>Nvidia</h5></div><div class="minersuppAMD"><h5>AMD</h5></div></div>
+        
+                <p>Supports GPUs from 3GB and up, by using either beamv3 or ethereum to mine!</p>
+                <br>
+                <p>Offers extra commands like custom GPU usage, temperature thresholds, and completely remove dev fee!</p>
+                <br>
+                <h4>Click to learn more</h4>
+                </div>
               </a>
             </div>
             <div class="column">
@@ -175,6 +201,19 @@
               </a>
             </div>
             <div class="column">
+              <a href="XMRigGPUGuide.html"> <!-- XMRig GPU CLI guide -->
+                <div class="cards"><h5>XMRig GPU</h5>
+				  <div class="suppgpus"><div class="minersuppNVIDIA"><h5>Nvidia</h5></div><div class="minersuppAMD"><h5>AMD</h5></div></div>
+				  
+                  <p>Mainly for 4GB+ VRAM GPUs, to mine Monero using the KawPow algorithm!</p>
+                  <br>
+                  <p>Offers extra commands like background mining, and nicehash pools!</p>
+                  <br>
+                  <h4>Click to learn more</h4>
+                  </div>
+              </a>
+            </div>
+            <div class="column">
               <a href="Gminer.html"> <!-- GMiner CLI guide -->
                 <div class="cards"><h5>GMiner</h5>
 				  <div class="suppgpus"><div class="minersuppNVIDIA"><h5>Nvidia</h5></div><div class="minersuppAMD"><h5>AMD</h5></div></div>
@@ -185,45 +224,6 @@
                   <br>
                   <h4>Click to learn more</h4>
                   </div>
-              </a>
-            </div>
-            <div class="column">
-              <a href="T-REX.html"> <!-- T-REX CLI guide -->
-                <div class="cards"><h5>T-REX</h5>
-				  <div class="suppgpus"><div class="minersuppNVIDIA"><h5>Nvidia</h5></div><div></div></div>
-				  
-                  <p>For Nvidia GPUs, mines ETH, ETC, and KawPow!</p>
-                  <br>
-                  <p>Offers low fees for mining, temperature limits, and GPU usage!</p>
-                  <br>
-                  <h4>Click to learn more</h4>
-                  </div>
-              </a>
-            </div>
-            <div class="column">
-              <a href="NBMinerGuide.html"> <!-- NBMiner CLI guide -->
-                <div class="cards"><h5>NBMiner</h5>
-				  <div class="suppgpus"><div class="minersuppNVIDIA"><h5>Nvidia</h5></div><div class="minersuppAMD"><h5>AMD</h5></div></div>
-				  
-                  <p>Supports GPUs from 3GB and up, by using either beamv3 or ethereum to mine!</p>
-                  <br>
-                  <p>Offers extra commands like custom GPU usage, temperature thresholds, and completely remove dev fee!</p>
-                  <br>
-                  <h4>Click to learn more</h4>
-                  </div>
-                </a>
-              </div>
-         <div class="column">
-                <a href="TeamRedMiner.html"> <!-- TeamRedMiner Guide -->
-                  <div class="cards"><h5>TeamRedMiner</h5>
-				  <div class="suppgpus"><div class="minersuppAMD"><h5>AMD</h5></div><div></div></div>
-				  
-                    <p>For AMD GPUs, mines ETH, ETC, and KawPow!</p>
-                    <br>
-                    <p>Offers extra commands like temp limits and on-the-go overclocking!</p>
-                    <br>
-                    <h4>Click to learn more</h4>
-                    </div>
               </a>
             </div>
 			 <div class="column">


### PR DESCRIPTION
Me and ozua agreeded last night it was a nice idea to change the order of the miners on the cli page to most likely to be used on top and least likely to be used on the bottom and also the overclocking guide on the bottom as well. 

I hope you like the idea as well 

Its been changed to 
phoenix, trex, treamdred, nbminer
xmrig cpu, xmrig gpu, gminer, overclocking

